### PR TITLE
adding port option to Net::SCP#start call

### DIFF
--- a/lib/net/netconf/ssh.rb
+++ b/lib/net/netconf/ssh.rb
@@ -89,7 +89,8 @@ module Netconf
     def scp
       @scp ||= Net::SCP.start(@args[:target],
                               @args[:username],
-                              password: @args[:password])
+                              password: @args[:password],
+                              port: @args[:port] || 22)
     end
   end # class: SSH
 end # module: Netconf


### PR DESCRIPTION
Added support for non-default SSH port when using SCP
