### PR TITLE
fix bug with loading Junos Netconf RPCs

### DIFF
--- a/lib/net/netconf/jnpr/rpc.rb
+++ b/lib/net/netconf/jnpr/rpc.rb
@@ -157,6 +157,12 @@ module Netconf
         end
         @trans.rpc_exec(rpc_nx)
       end
+
+      def rollback(n = 0)
+        ArgumentError "rollback between 0 and 49 only" unless n.between?(0,49)
+        reply = load_configuration(rollback: n)
+        !reply.xpath('//ok').empty? # return true or false to indicate success or not
+      end
     end # module: JUNOS
   end # module: RPC
 end # module: Netconf

--- a/lib/net/netconf/jnpr/rpc.rb
+++ b/lib/net/netconf/jnpr/rpc.rb
@@ -30,14 +30,6 @@ module Netconf
         @trans.rpc_exec(rpc)
       end
 
-      def nokogiri_case(arg)
-        filter = case arg
-                 when Nokogiri::XML::Builder  then arg.doc.root
-                 when Nokogiri::XML::Document then arg.root
-                 else arg
-                 end
-      end
-
       def get_configuration(*args)
         filter = nil
 
@@ -163,6 +155,17 @@ module Netconf
         reply = load_configuration(rollback: n)
         !reply.xpath('//ok').empty? # return true or false to indicate success or not
       end
+
+      private
+
+      def nokogiri_case(arg)
+        filter = case arg
+                 when Nokogiri::XML::Builder  then arg.doc.root
+                 when Nokogiri::XML::Document then arg.root
+                 else arg
+                 end
+      end
+
     end # module: JUNOS
   end # module: RPC
 end # module: Netconf


### PR DESCRIPTION
Hi @kkirsche,

I've been doing some development work on a gem that has net-netconf as a dependency. It's taken me most of today but I finally found the source of a rather odd intermittent bug. Any methods defined after nokogiri_case in lib/net/netconf/jnpr/rpc.rb were not being loaded. This caused certain tests to fail.

I've moved nokogiri_case to a be private method. This seems to have fixed the problem. It also strikes me that nokogir_case should be a private method - I cannot see why this would need to be public - so this changes makes structural sense too (at least to me).

I just noticed the commits in this pull request and it includes the previously merged pull request (rollback function). This is because I forgot to rebase my repo from yours before making this pull request. I'll make sure I do that before the next pull request. ;)
