### PR TITLE
Send RPC::MSG_END after hello

### DIFF
--- a/lib/net/netconf/transport.rb
+++ b/lib/net/netconf/transport.rb
@@ -70,6 +70,7 @@ module Netconf
     
     def trans_send_hello
       trans_send( Netconf::RPC::MSG_HELLO )
+      trans_send( RPC::MSG_END )
     end
     
     def has_capability?( capability )


### PR DESCRIPTION
Should be there and prevents lockup with recent net-ssh. Without this net-netconf gets stuck in receive waiting for a response.
