### PR TITLE
Netconf.gemspec

### DIFF
--- a/netconf.gemspec
+++ b/netconf.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.authors = ["Kevin Kirsche", "Jeremy Schulman", "Ankit Jain"]
   s.email = 'kev.kirsche@gmail.com'
   s.files = FileList['lib/net/**/*.rb', 'examples/**/*.rb']
-  s.license = 'BSD 2'
+  s.license = 'BSD-2-Clause'
   s.add_dependency('nokogiri', '~> 1.6')
   s.add_dependency('net-ssh', '>= 2.9', '< 3.3')
   s.add_dependency('net-scp', '~> 1.2')

--- a/netconf.gemspec
+++ b/netconf.gemspec
@@ -13,6 +13,6 @@ Gem::Specification.new do |s|
   s.files = FileList['lib/net/**/*.rb', 'examples/**/*.rb']
   s.license = 'BSD 2'
   s.add_dependency('nokogiri', '~> 1.6')
-  s.add_dependency('net-ssh', '~> 2.9')
+  s.add_dependency('net-ssh', '>= 2.9', '< 3.3')
   s.add_dependency('net-scp', '~> 1.2')
 end


### PR DESCRIPTION
I tried to use net-netconf from within a chef recipe, however, net-ssh > 2.9 is used there so and then fails to active.

After changing the HELLO to include an RPC::END the later version of net-ssh seems to be working fine.
