### PR TITLE
 * supports block for not defined rpc (rpc missing_method)

### DIFF
--- a/lib/net/netconf/rpc.rb
+++ b/lib/net/netconf/rpc.rb
@@ -19,7 +19,7 @@ module Netconf
       # autogenerate an <rpc>, converting underscores (_)
       # to hyphens (-) along the way ...
 
-      def Builder.method_missing( method, params = nil, attrs = nil )
+      def Builder.method_missing( method, params = nil, attrs = nil, &block )
 
         rpc_name = method.to_s.tr('_','-').to_sym
 
@@ -38,6 +38,12 @@ module Netconf
         else
           # -- no params
           rpc_nx = Nokogiri::XML("<rpc><#{rpc_name}/></rpc>").root
+
+          if block
+            Nokogiri::XML::Builder.with( rpc_nx.at( rpc_name )){ |xml|
+              block.call( xml )
+            }
+          end
         end
 
         # if a block is given it is used to set the attributes of the toplevel element
@@ -61,8 +67,8 @@ module Netconf
         end
       end
 
-      def method_missing( method, params = nil, attrs = nil )
-        @trans.rpc_exec( Netconf::RPC::Builder.send( method, params, attrs ))
+      def method_missing( method, params = nil, attrs = nil , &block )
+        @trans.rpc_exec( Netconf::RPC::Builder.send( method, params, attrs , &block ))
       end
     end # class: Executor
 


### PR DESCRIPTION
This request contains some changes for supports block in general RPC call like as get-config/edit-config.
It introduce the ability to use nested elements in RPC request which required by some devices.

Example for use(update-certificate RPC for Pulse Secure DMI):

```
dev = Netconf::SSH.new(login)
dev.open

dev.rpc.update_certificate{|x|
  x.type 'DEVICE_CERT'
  x.send(:'subject-common-name', 'cn.example.net')
  x.send(:'external-interfaces'){
    x.send(:'external-interface', '<External Port>')
  }
  x.send(:'internal-interfaces'){
    x.send(:'internal-interface', '<Internal Port>')
  }
  x.send(:'management-interface', 'true')
}
```
